### PR TITLE
Add retries & raise to connect api

### DIFF
--- a/lhv.gemspec
+++ b/lhv.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'keystores'
   spec.add_runtime_dependency 'nokogiri'
+  spec.add_runtime_dependency 'logger'
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/lib/lhv.rb
+++ b/lib/lhv.rb
@@ -1,6 +1,7 @@
 require 'net/http'
 
 require 'keystores'
+require 'logger'
 require 'nokogiri'
 
 require "lhv/version"
@@ -13,5 +14,13 @@ module Lhv
 
   def self.root
     Pathname(File.expand_path('../', __dir__))
+  end
+
+  def self.logger
+    @@logger ||= Logger.new(STDOUT)
+  end
+
+  def self.logger=(logger)
+    @@logger = logger
   end
 end


### PR DESCRIPTION
When connecting to external service and Net::OpenTimeout occurs, API now tries to
reconnect 3 times, when raises an error. All retries and error are logged to
standard logger.

See https://github.com/internetee/registry/issues/1474