### PR TITLE
Remove keystores from gemspec

### DIFF
--- a/lhv.gemspec
+++ b/lhv.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'keystores'
   spec.add_runtime_dependency 'logger'
   spec.add_runtime_dependency 'nokogiri'
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/lib/lhv.rb
+++ b/lib/lhv.rb
@@ -1,6 +1,5 @@
 require 'net/http'
 
-require 'keystores'
 require 'logger'
 require 'nokogiri'
 


### PR DESCRIPTION
Removes `keystores` from gemspec, because it's not needed. It overwrites some OpenSSL API which results in default ruby  implementation of `OpenSSL` methods to fail when being in use by `registry`.